### PR TITLE
商品削除機能の実装

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,6 +1,6 @@
 class ItemsController < ApplicationController
   before_action :authenticate_user!, except: [:index, :show]
-  before_action :set_item, only: [:show, :edit, :update]
+  before_action :set_item, only: [:show, :edit, :update, :destroy]
 
   def index
     @items = Item.includes(:user).order(created_at: :desc)
@@ -33,6 +33,15 @@ class ItemsController < ApplicationController
       redirect_to item_path(item_params)
     else
       render :edit
+    end
+  end
+
+  def destroy
+    if @item.user_id == current_user.id
+      @item.destroy
+      redirect_to root_path
+    else
+      redirect_to root_path
     end
   end
 

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -27,7 +27,7 @@
       <% if current_user.id == @item.user_id %>
         <%= link_to "商品の編集", edit_item_path(@item), method: :get, class: "item-red-btn" %>
         <p class="or-text">or</p>
-        <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>
+        <%= link_to "削除", item_path(@item), method: :delete, class:"item-destroy" %>
       <% else %>
         <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
       <% end %>


### PR DESCRIPTION
# What
## 商品削除機能の実装
- ログインしている出品者かつ自身が出品した商品を削除できるように実装

## 確認動画
- ログイン状態の出品者のみ、詳細ページの削除ボタンを押すと、出品した商品を削除できる（テスト出品さんでログイン）
https://gyazo.com/18f149a99c7d010264119966477e13e2
- データベースからも削除されているか確認
https://gyazo.com/8ab76882de50ab869ac43c24392ee2b3
- 購入者側だと削除ボタンが表示されていない（フリマ購入さんでログイン）
https://gyazo.com/95fd8df44b7dd3d6f28c05259047d46d
- 未ログインだと何もボタンが表示されていない
https://gyazo.com/63ad59fce196176fa473f4d408c0cbb8


# Why
- 出品した商品を削除することができるため
- 商品を出品した出品者以外が削除できないようにするため
